### PR TITLE
fix(ci): correct Docker build context for release workflows

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -232,7 +232,8 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          context: ./${{ matrix.service }}
+          context: .
+          file: ./${{ matrix.service }}/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -76,7 +76,8 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          context: ./${{ matrix.service }}
+          context: .
+          file: ./${{ matrix.service }}/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
The Dockerfiles expect to COPY from the repository root, not from
within the service directory.

Changed:
- context: ./${{ matrix.service }} → context: .
- Added: file: ./${{ matrix.service }}/Dockerfile

This allows the Dockerfile to access both 'backend' and 'rag_service'
directories as needed by COPY instructions.

Fixes error:
  ERROR: "/rag_service": not found
  failed to calculate checksum of ref

Affected workflows:
- manual-release.yml
- release-please.yml

Note: build-containers.yml already had correct context.